### PR TITLE
Add support for dynamic credentials engines

### DIFF
--- a/pydantic2_settings_vault/features/settings_source/cache.py
+++ b/pydantic2_settings_vault/features/settings_source/cache.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 
 from pydantic import SecretStr
 
-_CACHE_KEY = tuple[str, int]
+_CACHE_KEY = tuple[str, int, str]
 
 
 @dataclass(frozen=True)
@@ -19,8 +19,8 @@ class VaultSecretCache:
         self._ttl_seconds = ttl_seconds
         self._entries: dict[_CACHE_KEY, _CacheEntry] = {}
 
-    def get(self, vault_path: str, kv_version: int) -> dict[str, SecretStr] | None:
-        key = (vault_path, kv_version)
+    def get(self, vault_path: str, kv_version: int, vault_engine_type: str) -> dict[str, SecretStr] | None:
+        key = (vault_path, kv_version, vault_engine_type)
         entry = self._entries.get(key)
         if entry is None:
             return None
@@ -33,6 +33,7 @@ class VaultSecretCache:
         self,
         vault_path: str,
         kv_version: int,
+        vault_engine_type: str,
         secrets: dict[str, SecretStr],
     ) -> None:
         expires_at = (
@@ -40,7 +41,7 @@ class VaultSecretCache:
             if self._ttl_seconds is not None
             else float("inf")
         )
-        self._entries[(vault_path, kv_version)] = _CacheEntry(
+        self._entries[(vault_path, kv_version, vault_engine_type)] = _CacheEntry(
             secrets=secrets,
             expires_at=expires_at,
         )

--- a/pydantic2_settings_vault/features/settings_source/source.py
+++ b/pydantic2_settings_vault/features/settings_source/source.py
@@ -74,11 +74,11 @@ class VaultConfigSettingsSource(PydanticBaseSettingsSource):
         return get_auth_backend_from_env()
 
     @staticmethod
-    def _get_field_vault_metadata(field_name: str, field: FieldInfo) -> tuple[str, str]:
+    def _get_field_vault_metadata(field_name: str, field: FieldInfo) -> tuple[str, str, str]:
         field_metadata = field.json_schema_extra or {}
         missing_metadata = [
             metadata_key
-            for metadata_key in ("vault_secret_path", "vault_secret_key")
+            for metadata_key in ("vault_secret_path", "vault_secret_key", "vault_engine_type")
             if not field_metadata.get(metadata_key)
         ]
 
@@ -92,6 +92,7 @@ class VaultConfigSettingsSource(PydanticBaseSettingsSource):
         return (
             str(field_metadata["vault_secret_path"]),
             str(field_metadata["vault_secret_key"]),
+            str(field_metadata["vault_engine_type"]),
         )
 
     def get_field_value(
@@ -114,26 +115,31 @@ class VaultConfigSettingsSource(PydanticBaseSettingsSource):
 
         d: dict[str, Any] = {}
 
-        async def _get_vault_fetch_targets() -> list[tuple[str, int]]:
+        async def _get_vault_fetch_targets() -> list[tuple[str, int, str]]:
             """Collect unique Vault paths to fetch, normalized per KV version."""
-            fetch_targets: dict[tuple[str, int], None] = {}
+            fetch_targets: dict[tuple[str, int, str], None] = {}
             for _fieldname, field in filter(
                 lambda item: item[1].json_schema_extra,
                 self.settings_cls.model_fields.items(),
             ):
-                vault_path, _vault_secret_key = self._get_field_vault_metadata(
+                vault_path, _vault_secret_key, vault_engine_type = self._get_field_vault_metadata(
                     field_name=_fieldname, field=field
                 )
                 field_metadata = field.json_schema_extra
                 metadata_dict = (
                     field_metadata if isinstance(field_metadata, dict) else {}
                 )
-                kv_version = resolve_kv_version(
-                    metadata_dict,
-                    default=default_kv_version,
-                )
-                normalized_path = normalize_kv_path(vault_path, kv_version)
-                fetch_targets[(normalized_path, kv_version)] = None
+                if vault_engine_type == 'kv':
+                    kv_version = resolve_kv_version(
+                        metadata_dict,
+                        default=default_kv_version,
+                    )
+                    normalized_path = normalize_kv_path(vault_path, kv_version)
+                elif vault_engine_type == 'creds':
+                    kv_version = 0
+                    normalized_path = vault_path
+                
+                fetch_targets[(normalized_path, kv_version, vault_engine_type)] = None
 
             return list(fetch_targets.keys())
 
@@ -145,18 +151,20 @@ class VaultConfigSettingsSource(PydanticBaseSettingsSource):
             _vault: InternalHttpVault,
             vault_path: str,
             kv_version: int,
+            vault_engine_type: str,
         ) -> dict[str, SecretStr]:
             if secret_cache is not None:
-                cached_secrets = secret_cache.get(vault_path, kv_version)
+                cached_secrets = secret_cache.get(vault_path, kv_version, vault_engine_type)
                 if cached_secrets is not None:
                     return cached_secrets
 
             secrets = await _vault.get_secrets(
                 vault_path=vault_path,
                 kv_version=kv_version,
+                vault_engine_type=vault_engine_type,
             )
             if secret_cache is not None:
-                secret_cache.set(vault_path, kv_version, secrets)
+                secret_cache.set(vault_path, kv_version, vault_engine_type, secrets)
             return secrets
 
         @reattempt(
@@ -181,8 +189,9 @@ class VaultConfigSettingsSource(PydanticBaseSettingsSource):
                             _vault=vault,
                             vault_path=vault_path,
                             kv_version=kv_version,
+                            vault_engine_type=vault_engine_type,
                         )
-                        for vault_path, kv_version in fetch_targets
+                        for vault_path, kv_version, vault_engine_type in fetch_targets
                     ]
                 )
 
@@ -195,7 +204,7 @@ class VaultConfigSettingsSource(PydanticBaseSettingsSource):
                 lambda item: item[1].json_schema_extra,
                 self.settings_cls.model_fields.items(),
             ):
-                vault_path, vault_secret_key = self._get_field_vault_metadata(
+                vault_path, vault_secret_key, vault_engine_type = self._get_field_vault_metadata(
                     field_name=field_name, field=field
                 )
 

--- a/pydantic2_settings_vault/features/settings_source/source.py
+++ b/pydantic2_settings_vault/features/settings_source/source.py
@@ -209,9 +209,14 @@ class VaultConfigSettingsSource(PydanticBaseSettingsSource):
                 )
 
                 if vault_secret_key in vault_secrets_dict:
-                    k[field_name] = vault_secrets_dict[
-                        vault_secret_key
-                    ].get_secret_value()
+                    if isinstance(vault_secrets_dict[vault_secret_key], SecretStr):
+                        k[field_name] = vault_secrets_dict[
+                            vault_secret_key
+                        ].get_secret_value()
+                    else:
+                        k[field_name] = vault_secrets_dict[
+                            vault_secret_key
+                        ]
                 else:
                     logger.error(
                         "Vault secret key %r for settings field %r was not found "

--- a/pydantic2_settings_vault/features/settings_source/validation.py
+++ b/pydantic2_settings_vault/features/settings_source/validation.py
@@ -18,7 +18,7 @@ from pydantic2_settings_vault.shared.infrastructure.kv_paths import (
 )
 from pydantic2_settings_vault.shared.infrastructure.vault_http import InternalHttpVault
 
-VAULT_METADATA_KEYS: tuple[str, str] = ("vault_secret_path", "vault_secret_key")
+VAULT_METADATA_KEYS: tuple[str] = ("vault_secret_path", "vault_secret_key", "vault_engine_type")
 
 
 @dataclass(frozen=True)

--- a/pydantic2_settings_vault/shared/infrastructure/creds_paths.py
+++ b/pydantic2_settings_vault/shared/infrastructure/creds_paths.py
@@ -1,0 +1,24 @@
+from typing import Any
+
+
+def normalize_creds_path(vault_path: str) -> str:
+    """Return the Vault HTTP API path for a logical database secret path."""
+    if "/" not in vault_path:
+        return vault_path
+
+    mount_point, secret_path = vault_path.split("/", maxsplit=1)
+    if not secret_path:
+        return vault_path
+
+    if secret_path.startswith("data/"):
+        return f"{mount_point}/{secret_path[5:]}"
+    return vault_path
+
+
+def extract_creds_secret_data(response_json: dict[str, Any]) -> dict[str, Any]:
+    """Extract the key/value map from a Vault database read response."""
+    data = response_json.get("data")
+    if not isinstance(data, dict):
+        raise ValueError("Vault response missing 'data' field")
+
+    return data

--- a/pydantic2_settings_vault/shared/infrastructure/vault_http.py
+++ b/pydantic2_settings_vault/shared/infrastructure/vault_http.py
@@ -1,9 +1,11 @@
+from datetime import datetime, timedelta
 from http import HTTPStatus
 import ssl
+from typing import Literal
 
 import aiohttp
+import truststore
 from aiohttp import ClientSession
-import certifi
 from pydantic import SecretStr
 
 from pydantic2_settings_vault.features.authentication.backends import VaultAuthBackend
@@ -12,6 +14,9 @@ from pydantic2_settings_vault.shared.infrastructure.kv_paths import (
     normalize_kv_path,
     resolve_kv_version_from_env,
 )
+from pydantic2_settings_vault.shared.infrastructure.creds_paths import (
+    extract_creds_secret_data
+)
 from pydantic2_settings_vault.shared.infrastructure.vault_client_config import (
     VaultClientConfig,
 )
@@ -19,7 +24,7 @@ from pydantic2_settings_vault.shared.infrastructure.vault_client_config import (
 CONST_HEADER_X_VAULT_TOKEN: str = "X-Vault-Token"
 CONST_HEADER_X_VAULT_NAMESPACE: str = "X-Vault-Namespace"
 
-ssl_context = ssl.create_default_context(cafile=certifi.where())
+ssl_context = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
 
 
 class InternalHttpVault:
@@ -137,10 +142,59 @@ class InternalHttpVault:
         self,
         vault_path: str,
         kv_version: int | None = None,
+        vault_engine_type: Literal['kv', 'creds'] = 'kv',
     ) -> dict[str, SecretStr]:
         if not self.token:
             raise ValueError("Authentication is mandatory")
 
+        if vault_engine_type == 'kv':
+            return await self.get_kv_secrets(vault_path, kv_version)
+        elif vault_engine_type == 'creds':
+            return await self.get_creds_secrets(vault_path)
+        else:
+            raise ValueError(f"Engine type {vault_engine_type} is not supported")
+    
+    async def get_creds_secrets(
+        self,
+        vault_path: str
+    ) -> dict[str, SecretStr | int]:
+        try:
+            headers = {
+                CONST_HEADER_X_VAULT_TOKEN: self.token.get_secret_value(),
+                **self._build_namespace_headers(),
+            }
+            async with self.session.get(
+                f"{self.url}/v1/{vault_path}",
+                headers=headers,
+            ) as response:
+                if response.status == HTTPStatus.OK:
+                    secrets = await response.json()
+                    ttl = secrets.get("lease_duration")
+                    iat = datetime.now()
+                    exp = iat + timedelta(seconds=ttl)
+                    secret_data = extract_creds_secret_data(secrets)
+                    result = {
+                        key: SecretStr(value) for key, value in secret_data.items()
+                    }
+                    result.update({'ttl': ttl, 'iat': iat, 'exp': exp})
+
+                    return result
+
+                error_msg = await response.text()
+                raise ValueError(
+                    f"Failed to retrieve secret from Vault path '{vault_path}'. "
+                    f"Error code: {response.status}. Error message: {error_msg}"
+                )
+        except Exception as exc:
+            await self.session.close()
+            raise exc
+
+
+    async def get_kv_secrets(
+        self,
+        vault_path: str,
+        kv_version: int | None = None,
+    ) -> dict[str, SecretStr]:
         resolved_kv_version = (
             kv_version if kv_version is not None else self.default_kv_version
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,12 +7,12 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "aiohttp>=3.10.10",
-    "certifi>=2025.1.31",
     "concurrency-limiter>=1.1.0",
     "cryptography>=46.0.7",
     "pydantic>=2.9.2",
     "pydantic-settings>=2.6.0",
     "reattempt>=1.1.3",
+    "truststore>=0.10.4"
 ]
 license = { text = "MIT" }
 url = "https://github.com/sylvainmouquet/pydantic2-settings-vault"


### PR DESCRIPTION
Hi! This library is impressive, but in my project I need to use dynamic credential engine (like Database or RabbitMQ), so I tried to add support for it. Also, in private environments it's common practice to use self-signed certificates, that are stored in system keychain as trusted. So here's my proposal:
1. Use system-trusted TLS certificates
2. Add support for dynamic credential engines

Here are use cases using my changes:
```python
from datetime import datetime
from pydantic import Field, computed_field
from pydantic2_settings_vault import VaultConfigSettingsSource
from pydantic_settings import BaseSettings, SettingsConfigDict

class S3Settings(BaseSettings):
    model_config = SettingsConfigDict(env_file='.env')
    _project_settings = ProjectSettings()
    
    AWS_ENDPOINT_URL: str
    AWS_ACCESS_KEY_ID: str = Field(
        json_schema_extra={
            "vault_secret_path": f"kv/neurocontrol/{_project_settings.NAME}/aws", 
            "vault_secret_key": "key_id", 
            "vault_engine_type": "kv"
        }
    )
    AWS_SECRET_ACCESS_KEY: str = Field(
        json_schema_extra={
            "vault_secret_path": f"kv/neurocontrol/{_project_settings.NAME}/aws", 
            "vault_secret_key": "secret_access_key", 
            "vault_engine_type": "kv"
        }
    )

    @classmethod
    def settings_customise_sources(
        cls,
        settings_cls,
        init_settings,
        env_settings,
        dotenv_settings,
        file_secret_settings,
    ):
        return (
            init_settings,
            env_settings,
            dotenv_settings,
            VaultConfigSettingsSource(settings_cls=settings_cls),
        )


class PostgresSettings(BaseSettings):
    model_config = SettingsConfigDict(env_prefix='POSTGRES_', env_file='.env')
    _project_settings = ProjectSettings()

USER: str = Field(
        json_schema_extra={
            "vault_secret_path": f"database/creds/{_project_settings.NAME}", 
            "vault_secret_key": "username", 
            "vault_engine_type": "creds"
        }
    )
    PASSWORD: str = Field(
        json_schema_extra={
            "vault_secret_path": f"database/creds/{_project_settings.NAME}", 
            "vault_secret_key": "password", 
            "vault_engine_type": "creds"
        }
    )
    CREDS_IAT: datetime = Field(
        json_schema_extra={
            "vault_secret_path": f"database/creds/{_project_settings.NAME}", 
            "vault_secret_key": "iat", 
            "vault_engine_type": "creds"
        }
    )
    CREDS_TTL: int = Field(
        json_schema_extra={
            "vault_secret_path": f"database/creds/{_project_settings.NAME}", 
            "vault_secret_key": "ttl", 
            "vault_engine_type": "creds"
        }
    )
    CREDS_EXP: datetime = Field(
        json_schema_extra={
            "vault_secret_path": f"database/creds/{_project_settings.NAME}", 
            "vault_secret_key": "exp", 
            "vault_engine_type": "creds"
        }
    )
    HOST: str
    PORT: int
    NAME: str

    @computed_field
    @property
    def pg_dsn(self) -> str:
        return f'postgres://{self.USER}:{self.PASSWORD}@{self.HOST}:{self.PORT}/{self.NAME}'

    @classmethod
    def settings_customise_sources(
        cls,
        settings_cls,
        init_settings,
        env_settings,
        dotenv_settings,
        file_secret_settings,
    ):
        return (
            init_settings,
            env_settings,
            dotenv_settings,
            VaultConfigSettingsSource(settings_cls=settings_cls),
        )
```


<img width="990" height="430" alt="kv secret" src="https://github.com/user-attachments/assets/6c00a5e7-5953-461e-8b23-c6e047d634df" />

```python-repl
>>> os.environ['AWS_ENDPOINT_URL'] = '<endpoint>'
>>> settings = S3Settings()
>>> print(settings)
AWS_ENDPOINT_URL='<endpoint>' AWS_ACCESS_KEY_ID='key_id' AWS_SECRET_ACCESS_KEY='test123123123'
```

<img width="990" height="937" alt="database connection configuration" src="https://github.com/user-attachments/assets/93341d82-c354-42f8-8921-a14885d0ddaa" />
<img width="990" height="684" alt="database role configuration" src="https://github.com/user-attachments/assets/3bc7f05e-30a1-4346-81d9-4b7fe722b5ea" />

```python-repl
>>> settings = PostgresSettings()
>>> print(settings)
USER='collector_2026_07_03T13_42_05Z' PASSWORD='F-bGsJqVE6C7bPAS1LSg' CREDS_IAT=datetime.datetime(2026, 7, 3, 13, 42, 5, 39836) CREDS_TTL=3600 CREDS_EXP=datetime.datetime(2026, 7, 3, 14, 42, 5, 39836) HOST='<host>' PORT=5432 NAME='<database>' pg_dsn='postgres://collector_2026_07_03T13_42_05Z:F-bGsJqVE6C7bPAS1LSg@<host>: 5432/<database>'
```

One problem I've created: now you need explicitly define which type of engine you use `kv` or `creds`. I didn't manage to set default value to `vault_engine_type` key of json extra schema.